### PR TITLE
[Patch] [DX-275] Automated PR: Use CF_REVISION in git-clone step

### DIFF
--- a/.codefresh/pr.yaml
+++ b/.codefresh/pr.yaml
@@ -9,7 +9,7 @@ steps:
     title: Cloning repository
     type: git-clone
     repo: BedeGaming/Dapperer
-    revision: ${{CF_BRANCH}}
+    revision: ${{CF_REVISION}}
     git: github
     stage: setup
 

--- a/.codefresh/release.yaml
+++ b/.codefresh/release.yaml
@@ -9,7 +9,7 @@ steps:
     title: Cloning repository
     type: git-clone
     repo: BedeGaming/Dapperer
-    revision: ${{CF_BRANCH}}
+    revision: ${{CF_REVISION}}
     git: github
     stage: setup
 


### PR DESCRIPTION
Switch to using CF_REVISION in git-clone step so restart builds are picking up the right commit SHA